### PR TITLE
Bar Chart: optional minimal bar height when value is 0

### DIFF
--- a/src/barChart.js
+++ b/src/barChart.js
@@ -32,6 +32,7 @@ export class BarChart {
     onClick,
     tooltipHtml,
     enableRoundedCorners = false,
+    minimalBarHeightForZero = false,
   }) {
     this.elChart = elChart;
     this.values = values;
@@ -69,6 +70,7 @@ export class BarChart {
     this.left = this.left.bind(this);
     this.clicked = this.clicked.bind(this);
     this.enableRoundedCorners = enableRoundedCorners;
+    this.minimalBarHeightForZero = minimalBarHeightForZero;
     this.init();
   }
 
@@ -352,14 +354,13 @@ export class BarChart {
       .selectAll(".bar-rect")
       .data(this.values)
       .join((enter) => enter.append("rect").attr("class", "bar-rect"))
-      .attr(
-        "x",
-        (d) =>
-          this.x(this.accessor.x(d)) + this.x.bandwidth() / 2 - barWidth / 2,
-      )
-      .attr("y", (d) => this.y(this.accessor.y(d) || 0))
+      .attr("x", (d) => this.x(this.accessor.x(d)) + this.x.bandwidth() / 2 - barWidth / 2)
+      .attr("y", (d) => this.y(Math.max(this.accessor.y(d), 0)))
       .attr("width", barWidth)
-      .attr("height", (d) => this.y(0) - this.y(this.accessor.y(d)) || 0)
+      .attr("height", (d) => {
+        const height = this.y(0) - this.y(this.accessor.y(d));
+        return this.minimalBarHeightForZero && this.accessor.y(d) === 0 ? 1 : Math.max(height, 0);
+      })
       .style("fill", (d) => this.accessor.color(d))
       .attr("rx", cornerRadius)
       .attr("ry", cornerRadius);

--- a/src/barChart.js
+++ b/src/barChart.js
@@ -354,12 +354,18 @@ export class BarChart {
       .selectAll(".bar-rect")
       .data(this.values)
       .join((enter) => enter.append("rect").attr("class", "bar-rect"))
-      .attr("x", (d) => this.x(this.accessor.x(d)) + this.x.bandwidth() / 2 - barWidth / 2)
+      .attr(
+        "x",
+        (d) =>
+          this.x(this.accessor.x(d)) + this.x.bandwidth() / 2 - barWidth / 2,
+      )
       .attr("y", (d) => this.y(Math.max(this.accessor.y(d), 0)))
       .attr("width", barWidth)
       .attr("height", (d) => {
         const height = this.y(0) - this.y(this.accessor.y(d));
-        return this.minimalBarHeightForZero && this.accessor.y(d) === 0 ? 1 : Math.max(height, 0);
+        return this.minimalBarHeightForZero && this.accessor.y(d) === 0
+          ? 1
+          : Math.max(height, 0);
       })
       .style("fill", (d) => this.accessor.color(d))
       .attr("rx", cornerRadius)


### PR DESCRIPTION
No bar looks odd when there is a trendline. Let's add the option to set the bar height to 1 pixel when the value is 0.

Before:
![Screenshot 2024-04-17 at 3 13 25 PM (1)](https://github.com/get-dx/d3-charts/assets/59296568/76b3cabf-8de0-4490-ae79-37aac87c2dec)

After:
![Screenshot 2024-04-17 at 5 07 04 PM (1)](https://github.com/get-dx/d3-charts/assets/59296568/944da343-0325-44ac-8253-aa2b0fb98451)

