### PR TITLE
Bar chart: centered tooltip in far right bar

### DIFF
--- a/src/barChart.js
+++ b/src/barChart.js
@@ -473,9 +473,7 @@ export class BarChart {
       this.x(this.accessor.x(this.tooltipData)) +
       this.x.bandwidth() / 2 -
       tooltipRect.width / 2;
-    if (x + tooltipRect.width > this.width) {
-      x = this.width - tooltipRect.width;
-    } else if (x < 0) {
+    if (x < 0) {
       x = 0;
     }
 


### PR DESCRIPTION
Prevent the incorrect alignment shown in this screenshot:
<img width="544" alt="Screenshot 2024-05-07 at 9 52 16 AM" src="https://github.com/get-dx/d3-charts/assets/59296568/9127ef40-f14d-4829-9cec-a797c0d6f308">
