### PR TITLE
Bar chart: always align tooltip vertically with top of bar

### DIFF
--- a/src/barChart.js
+++ b/src/barChart.js
@@ -480,9 +480,6 @@ export class BarChart {
     const yOffset = 8;
     let y =
       this.y(this.accessor.y(this.tooltipData)) - yOffset - tooltipRect.height;
-    if (y < 0) {
-      y = this.y(this.accessor.y(this.tooltipData)) + yOffset;
-    }
 
     this.tooltip.style("transform", `translate(${x}px,${y}px)`);
   }


### PR DESCRIPTION
Favor this:
<img width="483" alt="Screenshot 2024-05-07 at 10 14 15 AM" src="https://github.com/get-dx/d3-charts/assets/59296568/1fb8fb3b-3307-4e99-9adb-2e5cf64320b9">

Over this:
<img width="371" alt="Screenshot 2024-05-07 at 10 14 20 AM" src="https://github.com/get-dx/d3-charts/assets/59296568/bae56f3b-f5e2-4f1c-a36e-037e3c09a627">
