### PR TITLE
Support X-axis labels for multi-line charts

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -218,6 +218,12 @@
           <div id="multi-line-1-chart" class="chart-container"></div>
         </div>
       </div>
+      <div class="card">
+        <div class="card-title">Multi-Line 2</div>
+        <div class="card-body">
+          <div id="multi-line-2-chart" class="chart-container"></div>
+        </div>
+      </div>
       <div class="card" style="grid-column: span 2">
         <div class="card-title">Bump Chart</div>
         <div class="card-body">
@@ -248,7 +254,7 @@
       // } from "../dist/main.js";
       } from "/src/main.js";
 
-      // Stacked area chart 
+      // Stacked area chart
       {
         const stackedAreaChart = new StackedAreaChart({
           elChart: document.getElementById("stacked-area-chart"),
@@ -256,7 +262,7 @@
             return `
               <div>${date.toLocaleDateString()}</div>
               ${series.map(d => `
-                <div>${d.name}: ${(d.percentage * 100).toFixed(1)}% (${d.count})</div>  
+                <div>${d.name}: ${(d.percentage * 100).toFixed(1)}% (${d.count})</div>
               `).join("")}
             `
           }
@@ -1031,6 +1037,38 @@
           elChart: document.getElementById("multi-line-1-chart"),
           showYAxisTickLabels: true,
           yAxisLabel: "Something",
+          showPoints: true,
+          tooltipHtml(ds) {
+            const date = ds[0].xValue;
+            return `
+            <div>
+              <div>${date}</div>
+              <table>
+                <tbody>
+                  ${ds.map(d => `
+                    <tr>
+                      <td>${d.series}</td>
+                      <td>${d.yValue}</td>
+                    </tr>
+                  `).join("")}
+                </tbody>
+              </table>
+            </div>
+            `
+          }
+        });
+        d3.json("data/multi_line_chart_dataset.json").then((data) => {
+          multiLine1.series = data.series;
+          multiLine1.values = data.values;
+          multiLine1.redraw();
+        })
+      }
+      {
+        const multiLine1 = new MultiLineChart({
+          elChart: document.getElementById("multi-line-2-chart"),
+          showYAxisTickLabels: true,
+          yAxisLabel: "Something",
+          xAxisLabel: "Something",
           showPoints: true,
           tooltipHtml(ds) {
             const date = ds[0].xValue;

--- a/example/index.html
+++ b/example/index.html
@@ -1064,7 +1064,7 @@
         })
       }
       {
-        const multiLine1 = new MultiLineChart({
+        const multiLine2 = new MultiLineChart({
           elChart: document.getElementById("multi-line-2-chart"),
           showYAxisTickLabels: true,
           yAxisLabel: "Something",
@@ -1090,9 +1090,9 @@
           }
         });
         d3.json("data/multi_line_chart_dataset.json").then((data) => {
-          multiLine1.series = data.series;
-          multiLine1.values = data.values;
-          multiLine1.redraw();
+          multiLine2.series = data.series;
+          multiLine2.values = data.values;
+          multiLine2.redraw();
         })
       }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@get-dx/d3-charts",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "description": "DX d3 charts",
   "main": "dist/main.js",
   "module": "dist/main.js",

--- a/src/multiLineChart.js
+++ b/src/multiLineChart.js
@@ -19,6 +19,7 @@ export class MultiLineChart {
     yAxisTickLabelSpread = 50,
     yAxisTickLabelFormat = (d) => d.toLocaleString(),
     yAxisLabel = "",
+    xAxisLabel = "",
     tooltipHtml,
   }) {
     this.elChart = elChart;
@@ -38,6 +39,7 @@ export class MultiLineChart {
     this.yAxisTickLabelSpread = yAxisTickLabelSpread;
     this.yAxisTickLabelFormat = yAxisTickLabelFormat;
     this.yAxisLabel = yAxisLabel;
+    this.xAxisLabel = xAxisLabel;
     this.tooltipHtml = tooltipHtml;
     this.resize = this.resize.bind(this);
     this.entered = this.entered.bind(this);
@@ -55,10 +57,7 @@ export class MultiLineChart {
   }
 
   setup() {
-    this.margin = {
-      top: 3,
-      bottom: 3,
-    };
+    this.margin = {};
 
     this.dotRadius = 2.5;
 
@@ -157,11 +156,7 @@ export class MultiLineChart {
     this.width = this.container.node().clientWidth;
     this.height = this.container.node().clientHeight;
 
-    this.y.range([this.height - this.margin.bottom, this.margin.top]);
-
     this.svg.attr("viewBox", [0, 0, this.width, this.height]);
-
-    this.focusLine.attr("y2", this.height - this.margin.bottom);
 
     if (this.values.length === 0 || this.series.length === 0) return;
 
@@ -170,8 +165,10 @@ export class MultiLineChart {
 
   render() {
     this.adjustXMargin();
+    this.adjustYMargin();
     this.renderXAxis();
     this.renderYAxis();
+    this.renderFocusLine();
     this.renderZeroLine();
     this.renderSeries();
   }
@@ -192,6 +189,18 @@ export class MultiLineChart {
     this.x.range([this.margin.left, this.width - this.margin.right]);
   }
 
+  adjustYMargin() {
+    this.margin.top = 3;
+    this.margin.bottom = 3;
+
+    this.showXAxisLabel = this.xAxisLabel !== "";
+    if (this.showXAxisLabel) {
+      this.margin.bottom += 20;
+    }
+
+    this.y.range([this.height - this.margin.bottom, this.margin.top]);
+  }
+
   renderXAxis() {
     this.g
       .selectAll(".axis--x")
@@ -205,7 +214,22 @@ export class MultiLineChart {
           .tickSize(-this.height + this.margin.top + this.margin.bottom),
       )
       .call((g) => g.select(".domain").remove())
-      .call((g) => g.selectAll(".tick text").remove());
+      .call((g) => g.selectAll(".tick text").remove())
+      .call((g) =>
+        g
+          .selectAll(".axis-title-text")
+          .data(this.showXAxisLabel ? [this.xAxisLabel] : [])
+          .join((enter) =>
+            enter
+              .append("text")
+              .attr("class", "axis-title-text")
+              .attr("fill", "currentColor")
+              .attr("text-anchor", "middle"),
+          )
+          .attr("x", (this.margin.left + this.width - this.margin.right) / 2)
+          .attr("y", this.margin.bottom - 4)
+          .text(d => d),
+      );
   }
 
   renderYAxis() {
@@ -264,6 +288,10 @@ export class MultiLineChart {
           )
           .text((d) => d),
       );
+  }
+
+  renderFocusLine() {
+    this.focusLine.attr("y2", this.height - this.margin.bottom);
   }
 
   renderZeroLine() {

--- a/src/multiLineChart.js
+++ b/src/multiLineChart.js
@@ -228,7 +228,7 @@ export class MultiLineChart {
           )
           .attr("x", (this.margin.left + this.width - this.margin.right) / 2)
           .attr("y", this.margin.bottom - 4)
-          .text(d => d),
+          .text((d) => d),
       );
   }
 


### PR DESCRIPTION
We want customers to be able to configure label copy for our charts in Data Studio.

The only missing one was the X-axis label for multi-line charts, which is added here.

<img width="1840" alt="Screenshot 2024-09-04 at 3 32 06 PM" src="https://github.com/user-attachments/assets/6c7556fa-a7cd-4386-adb3-aba0e9c994b8">

<img width="1840" alt="Screenshot 2024-09-04 at 3 34 03 PM" src="https://github.com/user-attachments/assets/beb46bd8-0ac5-4be6-94d2-4410e4cd1627">

https://docs.google.com/document/d/1Af5NBZxD-hw20mGmJBmnpavRHbGsk2KNnoPOXC0yBlk/edit?pli=1